### PR TITLE
move: rename -> `action`

### DIFF
--- a/src/legal/action.gleam
+++ b/src/legal/action.gleam
@@ -1,0 +1,58 @@
+import chess/board.{type Board}
+import chess/color.{type Color}
+import chess/game.{type Game, Game}
+import legal/move.{type Move}
+
+pub type Action {
+  Basic(move: Move)
+  Capture(move: Move)
+  Passant(move: Move)
+  QueenCastle(move: Move)
+  KingCastle(move: Move)
+}
+
+pub fn to_string(action: Action) -> String {
+  let move_str = action.move |> move.to_string
+  let action_str = case action {
+    Basic(_) -> ""
+    Capture(_) -> "Capture "
+    Passant(_) -> "En Passant "
+    QueenCastle(_) -> "Castle Queenside "
+    KingCastle(_) -> "Castle Kingside "
+  }
+
+  action_str <> move_str
+}
+
+/// Simple function that calls the correct `apply` function for the given
+/// action. This lets en passant, queen castle, etc, be executed differently
+/// when we're actually applying moves.
+pub fn apply(game: Game, action: Action) -> Game {
+  let board = game.board
+  let move = action.move
+  let new_board = case action {
+    Basic(_) -> move.apply(board, move)
+
+    // We currently handle captures the same - but having them as Capture means
+    // we can filter for them in a list of moves
+    Capture(_) -> move.apply(board, move)
+
+    QueenCastle(_) -> apply_queen_castle(board, action, game.color)
+    KingCastle(_) -> apply_king_castle(board, action, game.color)
+
+    Passant(_) -> apply_passant(board, action)
+  }
+  Game(..game, board: new_board)
+}
+
+fn apply_king_castle(_board: Board, _action: Action, _color: Color) -> Board {
+  panic as "Unimplemented!"
+}
+
+fn apply_queen_castle(_board: Board, _action: Action, _color: Color) -> Board {
+  panic as "Unimplemented!"
+}
+
+fn apply_passant(_board: Board, _action: Action) -> Board {
+  panic as "Unimplemented!"
+}

--- a/src/legal/generate.gleam
+++ b/src/legal/generate.gleam
@@ -16,11 +16,13 @@ import gleam/bool
 import gleam/int
 import gleam/list
 import gleam/result
-import legal/move.{type Move, Capture, Move, PassantMove}
+import legal/action.{type Action, Passant}
+import legal/move.{Move}
 
-/// Given a board and a position, get all the legal moves that the piece at that
-/// position can make. Returns an error if the position contained None.
-pub fn legal_moves(game: Game, pos: Position) -> Result(List(Move), String) {
+/// Given a board and a position, get all the legal actions that the piece at that
+/// position can make. An Action wraps a Move, so we can differentiate things like
+/// en passant.Returns an error if the position contained None.
+pub fn legal_actions(game: Game, pos: Position) -> Result(List(Action), String) {
   let board = game.board
   let square = board.get_pos(board, pos)
 
@@ -28,32 +30,37 @@ pub fn legal_moves(game: Game, pos: Position) -> Result(List(Move), String) {
   use piece <- result.try(square |> square.to_piece)
 
   case piece {
-    Pawn(_) -> legal_pawn_moves(game, pos, piece) |> Ok
-    Knight(_) -> legal_knight_moves(game, pos, piece) |> Ok
+    Pawn(_) -> legal_pawn_actions(game, pos, piece) |> Ok
+    Knight(_) -> legal_knight_actions(game, pos, piece) |> Ok
     _ -> {
       // If this gets an error, there's a logic failure!
       let assert Ok(sliding_piece) = piece |> sliding.new
 
-      legal_sliding_moves(game, pos, sliding_piece)
+      legal_sliding_actions(game, pos, sliding_piece)
       |> Ok
     }
   }
 }
 
-fn legal_pawn_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {
-  let vertical_moves = pawn_vertical_moves(game, pos, piece)
-  let diagonal_moves = pawn_diagonal_moves(game, pos, piece)
-  let en_passant = en_passant_move(game, pos, piece)
+fn legal_pawn_actions(game: Game, pos: Position, piece: Piece) -> List(Action) {
+  let vertical_actions = pawn_vertical_actions(game, pos, piece)
+  let diagonal_actions = pawn_diagonal_actions(game, pos, piece)
+  let en_passant = en_passant_actions(game, pos, piece)
 
-  let en_passant_moves = case en_passant {
+  let en_passant_actions = case en_passant {
     option.Some(move) -> move |> list.wrap
     option.None -> []
   }
 
-  list.append(vertical_moves, diagonal_moves) |> list.append(en_passant_moves)
+  list.append(vertical_actions, diagonal_actions)
+  |> list.append(en_passant_actions)
 }
 
-fn pawn_vertical_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {
+fn pawn_vertical_actions(
+  game: Game,
+  pos: Position,
+  piece: Piece,
+) -> List(Action) {
   let board = game.board
 
   // A 1-based index, with 0 representing the bottom row
@@ -77,19 +84,20 @@ fn pawn_vertical_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {
 
   let square = board.get_pos(board, new_pos)
 
-  // Only write the move to the legal moves list if the space in front of us is empty
-  // We store `was_legal` so we can tell if it's possible to move two away as well
-  let #(moves, was_legal) = case square {
+  // Only write the actions to the legal actions list if the space in front of us is
+  // empty. We store `was_legal` so we can tell if it's possible to move two away as
+  // well
+  let #(actions, was_legal) = case square {
     square.Some(_) -> #([], False)
     square.None -> {
-      let move = Move(pos, new_pos)
-      #(move |> list.wrap, True)
+      let action = Move(pos, new_pos) |> action.Basic
+      #(action |> list.wrap, True)
     }
   }
 
   // We can only double move if we're on the right rank, and moving one was legal.
   // If not, exit early.
-  use <- bool.guard(can_double_move == False || was_legal == False, moves)
+  use <- bool.guard(can_double_move == False || was_legal == False, actions)
 
   // The `can_double_move` check means we're in no danger of hitting the edge
   // of the board
@@ -99,15 +107,19 @@ fn pawn_vertical_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {
   let square = board.get_pos(board, new_pos)
 
   case square {
-    square.Some(_) -> moves
+    square.Some(_) -> actions
     square.None -> {
-      let move = Move(pos, new_pos)
-      [move, ..moves]
+      let double = Move(pos, new_pos) |> action.Basic
+      [double, ..actions]
     }
   }
 }
 
-fn pawn_diagonal_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {
+fn pawn_diagonal_actions(
+  game: Game,
+  pos: Position,
+  piece: Piece,
+) -> List(Action) {
   let board = game.board
 
   let dirs = case piece.color {
@@ -134,7 +146,7 @@ fn pawn_diagonal_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {
   }
 
   // Based on the piece found in the direction, and whether that piece is an enemy,
-  // decide whether the move is legal. Error means illegal.
+  // decide whether the action is legal. Error means illegal.
   case square, is_enemy {
     // No piece to capture.
     square.None, _ -> Error("")
@@ -143,12 +155,12 @@ fn pawn_diagonal_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {
     square.Some(_), False -> Error("")
 
     // There's a piece in that direction, and it's an enemy. Legal! Use the Capture
-    // constructor, so we can give this move higher priority in evaluation
-    square.Some(_), True -> Capture(pos, pos_in_dir) |> Ok
+    // constructor, so we can give this action higher priority in evaluation
+    square.Some(_), True -> Move(pos, pos_in_dir) |> action.Capture |> Ok
   }
 }
 
-fn en_passant_move(game: Game, pos: Position, piece: Piece) -> Option(Move) {
+fn en_passant_actions(game: Game, pos: Position, piece: Piece) -> Option(Action) {
   // 0-based indices
   let rank = pos |> position.get_rank |> rank.to_index
   let file = pos |> position.get_file |> file.to_index
@@ -174,8 +186,8 @@ fn en_passant_move(game: Game, pos: Position, piece: Piece) -> Option(Move) {
       // The cool thing about the fen representation of passant is that it stores
       // the position that the passant piece skipped over - meaning we can just move
       // there.
-      let move = PassantMove(pos, passant_pos)
-      move |> option.Some
+      let passant = Move(pos, passant_pos) |> Passant
+      passant |> option.Some
     }
 
     _, _ -> option.None
@@ -183,19 +195,19 @@ fn en_passant_move(game: Game, pos: Position, piece: Piece) -> Option(Move) {
 }
 
 /// TODO
-fn legal_knight_moves(
+fn legal_knight_actions(
   _game: Game,
   _position: Position,
   _piece: Piece,
-) -> List(Move) {
+) -> List(Action) {
   []
 }
 
-fn legal_sliding_moves(
+fn legal_sliding_actions(
   game: Game,
   current_pos: Position,
   sliding_piece: SlidingPiece,
-) -> List(Move) {
+) -> List(Action) {
   let board = game.board
 
   sliding.piece_directions(sliding_piece)
@@ -206,8 +218,8 @@ fn legal_sliding_moves(
     let piece_distance = sliding.piece_distance(sliding_piece, dir)
 
     // Store the distance until another piece is found, or we hit a wall. Custom type
-    // that can either be a Capture or a NonCapture, so we can use the custom Move
-    // constructor for captures.
+    // that can either be a Capture or a NonCapture, so we can mark the action as
+    // a capture if needed.
     let obstructed =
       board.obstructed_distance(board, current_pos, dir, sliding_piece.color)
 
@@ -216,20 +228,20 @@ fn legal_sliding_moves(
 
     case obstructed {
       board.Capture(_) -> {
-        // Create the capture move first - then call the function to generate the
-        // non-captures for all the moves that were of a smaller distance (if they
+        // Create the capture action first - then call the function to generate the
+        // non-captures for all the actions that were of a smaller distance (if they
         // exist)
         let assert Ok(capture_pos) =
           position.from_offset(current_pos, max_distance, dir)
-        let capture = Capture(current_pos, capture_pos)
+        let capture = Move(current_pos, capture_pos) |> action.Capture
 
         let non_captures =
-          sliding_moves_for_dir(current_pos, max_distance - 1, dir)
+          sliding_actions_for_dir(current_pos, max_distance - 1, dir)
 
         list.prepend(non_captures, capture)
       }
       board.NonCapture(_) -> {
-        sliding_moves_for_dir(current_pos, max_distance, dir)
+        sliding_actions_for_dir(current_pos, max_distance, dir)
       }
     }
   })
@@ -237,18 +249,18 @@ fn legal_sliding_moves(
   |> list.flatten
 }
 
-/// Generates a list of moves from a position and in a direction, up to some maximum
-/// distance. This does *not* generate moves with the Capture() record - you're
-/// expected to use this to generate your non-captures, and handle captures on your
-/// own. This also doesn't care about your piece type - so make sure `max_distance`
-/// takes Kings into account, since they can only move by one square!
-fn sliding_moves_for_dir(
+/// Generates a list of actions from a position and in a direction, up to some
+/// maximum distance. This does *not* generate actions with the Capture() record -
+/// you're expected to use this to generate your non-captures, and handle captures on
+/// your own. This also doesn't care about your piece type - so make sure
+/// `max_distance` takes Kings into account, since they can only move by one square!
+fn sliding_actions_for_dir(
   current_pos: Position,
   max_distance: Int,
   dir: Direction,
-) -> List(Move) {
+) -> List(Action) {
   // iv.range isn't very safe - given the input `(1,0)`, it doesn't give an error.
-  // We have to guard against the case that there are no moves from our current
+  // We have to guard against the case that there are no actions from our current
   // position.
   use <- bool.guard(max_distance == 0, list.new())
   let distances = list.range(1, max_distance)
@@ -259,6 +271,6 @@ fn sliding_moves_for_dir(
     // if it ever fails, we must've somehow had invalid logic. Insta-fail!
     let assert Ok(new_pos) = position.from_offset(current_pos, dist, dir)
 
-    Move(current_pos, new_pos)
+    Move(current_pos, new_pos) |> action.Basic
   })
 }

--- a/src/legal/move.gleam
+++ b/src/legal/move.gleam
@@ -1,69 +1,29 @@
 import chess/board.{type Board}
-import chess/color.{type Color}
-import chess/game.{type Game, Game}
 import chess/position.{type Position}
 import chess/square
+import gleam/order.{type Order}
 
 pub type Move {
   Move(from: Position, to: Position)
-  Capture(from: Position, to: Position)
-  PassantMove(from: Position, to: Position)
-  QueenCastle(from: Position, to: Position)
-  KingCastle(from: Position, to: Position)
 }
 
-pub fn to_string(move: Move) -> String {
-  let from_str = move.from |> position.to_string
-  let to_str = move.to |> position.to_string
-  let move_type = case move {
-    Move(_, _) -> ""
-    Capture(_, _) -> "Capture "
-    PassantMove(_, _) -> "En Passant "
-    QueenCastle(_, _) -> "Castle Queenside "
-    KingCastle(_, _) -> "Castle Kingside "
-  }
-
-  move_type <> from_str <> " -> " <> to_str
+pub fn compare(first: Move, second: Move) -> Order {
+  // First try to sort on `from` - if you get `Eq`, then sort on `to`. Only if that
+  // ALSO returns Eq do we return Eq.
+  use <- order.lazy_break_tie(position.compare(first.from, second.from))
+  position.compare(first.to, second.to)
 }
 
-/// Simple move function that moves a piece to another place on the board,
-/// capturing if another piece is at the target square. This function
-/// doesn't encode any logic about legal moves - you can make a piece go
-/// anywhere with this as it stands.
-/// I would put this in the `board` class, but then I get circular
-/// dependency issues.
-pub fn apply(game: Game, move: Move) -> Game {
-  let board = game.board
-  let new_board = case move {
-    Move(_, _) -> apply_move(board, move)
-
-    // We currently handle captures the same - but having them as Capture means
-    // we can filter for them in a list of moves
-    Capture(_, _) -> apply_move(board, move)
-
-    QueenCastle(_, _) -> apply_queen_castle(board, move, game.color)
-    KingCastle(_, _) -> apply_king_castle(board, move, game.color)
-
-    PassantMove(_, _) -> apply_passant(board, move)
-  }
-  Game(..game, board: new_board)
-}
-
-fn apply_move(board: Board, move: Move) -> Board {
+pub fn apply(board: Board, move: Move) -> Board {
   let square = board.get_pos(board, move.from)
   board
   |> board.set_pos(move.from, square.None)
   |> board.set_pos(move.to, square)
 }
 
-fn apply_king_castle(_board: Board, _move: Move, _color: Color) -> Board {
-  panic as "Unimplemented!"
-}
+pub fn to_string(move: Move) {
+  let from_str = move.from |> position.to_string
+  let to_str = move.to |> position.to_string
 
-fn apply_queen_castle(_board: Board, _move: Move, _color: Color) -> Board {
-  panic as "Unimplemented!"
-}
-
-fn apply_passant(_board: Board, _move: Move) -> Board {
-  panic as "Unimplemented!"
+  from_str <> " -> " <> to_str
 }

--- a/test/legal/apply.gleam
+++ b/test/legal/apply.gleam
@@ -2,6 +2,7 @@ import birdie
 import chess/board
 import chess/game
 import chess/position
+import legal/action
 import legal/move.{Move}
 
 pub fn move_forward_test() {
@@ -9,9 +10,9 @@ pub fn move_forward_test() {
 
   let assert Ok(from) = position.new("e2")
   let assert Ok(to) = position.new("e4")
-  let move = Move(from, to)
+  let action = Move(from, to) |> action.Basic
 
-  let game = move.apply(game, move)
+  let game = action.apply(game, action)
 
   game.board |> board.to_string |> birdie.snap(title: "Pawn from e2 to e4!")
 }
@@ -21,9 +22,9 @@ pub fn move_capture_test() {
 
   let assert Ok(from) = position.new("e2")
   let assert Ok(to) = position.new("e7")
-  let move = Move(from, to)
+  let action = Move(from, to) |> action.Capture
 
-  let game = move.apply(game, move)
+  let game = action.apply(game, action)
 
   game.board
   |> board.to_string

--- a/test/legal/pawn.gleam
+++ b/test/legal/pawn.gleam
@@ -3,6 +3,7 @@ import chess/color
 import chess/game
 import chess/piece
 import gleam/io
+import legal/action
 
 import chess/board
 import chess/position
@@ -12,7 +13,6 @@ import gleam/list
 import gleam/string
 
 import legal/generate
-import legal/move
 
 pub fn white_pawn_test() {
   let game = game.initial()
@@ -24,10 +24,10 @@ pub fn white_pawn_test() {
   let game =
     game.setup_board(game, fn(board) { board.set_pos(board, pos, pawn_square) })
 
-  let assert Ok(legal_moves) = generate.legal_moves(game, pos)
+  let assert Ok(legal_actions) = generate.legal_actions(game, pos)
 
-  legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
+  legal_actions
+  |> list.map(fn(action) { action |> action.to_string })
   |> string.inspect
   |> birdie.snap("White pawn on e4 can only go to e5!")
 }
@@ -42,10 +42,10 @@ pub fn black_pawn_test() {
   let game =
     game.setup_board(game, fn(board) { board.set_pos(board, pos, pawn_square) })
 
-  let assert Ok(legal_moves) = generate.legal_moves(game, pos)
+  let assert Ok(legal_actions) = generate.legal_actions(game, pos)
 
-  legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
+  legal_actions
+  |> list.map(fn(action) { action |> action.to_string })
   |> string.inspect
   |> birdie.snap("Black pawn on e4 can only go to e3!")
 }
@@ -60,10 +60,10 @@ pub fn white_pawn_double_move_test() {
   let game =
     game.setup_board(game, fn(board) { board.set_pos(board, pos, pawn_square) })
 
-  let assert Ok(legal_moves) = generate.legal_moves(game, pos)
+  let assert Ok(legal_actions) = generate.legal_actions(game, pos)
 
-  legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
+  legal_actions
+  |> list.map(fn(action) { action |> action.to_string })
   |> string.inspect
   |> birdie.snap("White pawn on e2 can go to e3 and e4!")
 }
@@ -78,10 +78,10 @@ pub fn black_pawn_double_move_test() {
   let game =
     game.setup_board(game, fn(board) { board.set_pos(board, pos, pawn_square) })
 
-  let assert Ok(legal_moves) = generate.legal_moves(game, pos)
+  let assert Ok(legal_actions) = generate.legal_actions(game, pos)
 
-  legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
+  legal_actions
+  |> list.map(fn(action) { action |> action.to_string })
   |> string.inspect
   |> birdie.snap("Black pawn on a7 can go to a6 and a5!")
 }
@@ -97,10 +97,10 @@ pub fn passant_test() {
   // The position of the white pawn that can now perform en passant
   let assert Ok(pawn_pos) = position.new("e5")
 
-  let assert Ok(legal_moves) = generate.legal_moves(game, pawn_pos)
+  let assert Ok(legal_actions) = generate.legal_actions(game, pawn_pos)
 
-  legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
+  legal_actions
+  |> list.map(fn(action) { action |> action.to_string })
   |> string.inspect
   |> birdie.snap("White pawn can go forward to e6, or en passant to d6!")
 }
@@ -111,13 +111,13 @@ pub fn capture_test() {
   let assert Ok(game) =
     game.new("rnbqkbnr/pppppppp/4P3/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1")
 
-  // The position of the white pawn that has two capture moves
+  // The position of the white pawn that has two capture actions
   let assert Ok(pawn_pos) = position.new("e6")
 
-  let assert Ok(legal_moves) = generate.legal_moves(game, pawn_pos)
+  let assert Ok(legal_actions) = generate.legal_actions(game, pawn_pos)
 
-  legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
+  legal_actions
+  |> list.map(fn(action) { action |> action.to_string })
   |> string.inspect
   |> birdie.snap("White pawn on e6 can capture on d7 or f7!")
 }

--- a/test/legal/sliding.gleam
+++ b/test/legal/sliding.gleam
@@ -1,5 +1,6 @@
 import birdie
 import chess/game
+import legal/action
 
 import chess/board
 import chess/position
@@ -14,7 +15,7 @@ import legal/move.{Move}
 pub fn queen_goes_up_test() {
   let game = game.initial()
 
-  // Get rid of the pawn on d2, so we can get the legal moves of the queen behind it
+  // Get rid of the pawn on d2, so we can get the legal actions of the queen behind
   let assert Ok(pawn_pos) = position.new("d2")
   let game =
     game.setup_board(game, fn(board) {
@@ -22,10 +23,10 @@ pub fn queen_goes_up_test() {
     })
 
   let assert Ok(queen_pos) = position.new("d1")
-  let assert Ok(legal_moves) = generate.legal_moves(game, queen_pos)
+  let assert Ok(legal_actions) = generate.legal_actions(game, queen_pos)
 
-  legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
+  legal_actions
+  |> list.map(fn(action) { action |> action.to_string })
   |> string.inspect
   |> birdie.snap(
     "Queen on d1 with no pawn in front of it can move to d{2-6}, and capture to d7!",
@@ -35,7 +36,7 @@ pub fn queen_goes_up_test() {
 pub fn bishop_test() {
   let game = game.initial()
 
-  // Get rid of the pawn on e2, so we can get the legal moves of the bishop it's
+  // Get rid of the pawn on e2, so we can get the legal actions of the bishop it's
   // blocking
   let assert Ok(pawn_pos) = position.new("e2")
   let game =
@@ -44,10 +45,10 @@ pub fn bishop_test() {
     })
 
   let assert Ok(bishop_pos) = position.new("f1")
-  let assert Ok(legal_moves) = generate.legal_moves(game, bishop_pos)
+  let assert Ok(legal_actions) = generate.legal_actions(game, bishop_pos)
 
-  legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
+  legal_actions
+  |> list.map(fn(action) { action |> action.to_string })
   |> string.inspect
   |> birdie.snap(
     "Bishop on f1 with no pawn on e2 can go to e2, d3, c4, b5, and a7!",
@@ -61,13 +62,13 @@ pub fn rook_test() {
   let assert Ok(old_pos) = position.new("h1")
   let assert Ok(new_pos) = position.new("d4")
 
-  let h1_rook_to_d4 = Move(old_pos, new_pos)
-  let game = move.apply(game, h1_rook_to_d4)
+  let h1_rook_to_d4 = Move(old_pos, new_pos) |> action.Basic
+  let game = action.apply(game, h1_rook_to_d4)
 
-  let assert Ok(legal_moves) = generate.legal_moves(game, new_pos)
+  let assert Ok(legal_actions) = generate.legal_actions(game, new_pos)
 
-  legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
+  legal_actions
+  |> list.map(fn(action) { action |> action.to_string })
   |> string.inspect
   |> birdie.snap("Rook on d4 can see all of rank 4, and d{3, 7}!")
 }


### PR DESCRIPTION
Now, we have a Move, and an Action. A Move is dead simple - just from
one position to another position. An Action is also dead simple - just
wraps a Move with a specific record. Akin to the split between Square
and Piece, this lets a function only deal with the relevant part. For
example, the Move module has a `to_string` for simply displaying
something like "a1 -> a2" - which the Action module can wrap to add
something like "Capture a1 -> a2". This leads to more modular code, and
better separation of concerns.
