### PR TITLE
generate: add knight logic

### DIFF
--- a/birdie_snapshots/bishop_on_f1_with_no_pawn_on_e2_can_go_on_that_whole_diagonal_a6,_b5,_c4,_d3,_and_e2.accepted
+++ b/birdie_snapshots/bishop_on_f1_with_no_pawn_on_e2_can_go_on_that_whole_diagonal_a6,_b5,_c4,_d3,_and_e2.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.6
+title: Bishop on f1 with no pawn on e2 can go on that whole diagonal: a6, b5, c4, d3, and e2!
+file: ./test/generate/sliding.gleam
+test_name: bishop_test
+---
+["f1 -> a6", "f1 -> b5", "f1 -> c4", "f1 -> d3", "f1 -> e2"]

--- a/birdie_snapshots/bishop_on_f1_with_no_pawn_on_e2_can_go_to_e2,_d3,_c4,_b5,_and_a7.accepted
+++ b/birdie_snapshots/bishop_on_f1_with_no_pawn_on_e2_can_go_to_e2,_d3,_c4,_b5,_and_a7.accepted
@@ -1,7 +1,0 @@
----
-version: 1.2.6
-title: Bishop on f1 with no pawn on e2 can go to e2, d3, c4, b5, and a7!
-file: ./test/generate/sliding.gleam
-test_name: bishop_test
----
-["f1 -> e2", "f1 -> d3", "f1 -> c4", "f1 -> b5", "f1 -> a6"]

--- a/birdie_snapshots/expected_all_the_valid_knight_moves_on_an_empty_board_b3,_b5,_c2,_c6,_e2,_e6,_f3,_and_f5.accepted
+++ b/birdie_snapshots/expected_all_the_valid_knight_moves_on_an_empty_board_b3,_b5,_c2,_c6,_e2,_e6,_f3,_and_f5.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.6
+title: Expected all the valid knight moves on an empty board - b3, b5, c2, c6, e2, e6, f3, and f5!
+file: ./test/generate/knight.gleam
+test_name: all_options_test
+---
+["d4 -> b3", "d4 -> b5", "d4 -> c2", "d4 -> c6", "d4 -> e2", "d4 -> e6", "d4 -> f3", "d4 -> f5"]

--- a/birdie_snapshots/expected_applying_an_invalid_offset_to_give_an_error.accepted
+++ b/birdie_snapshots/expected_applying_an_invalid_offset_to_give_an_error.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.6
+title: Expected applying an invalid offset to give an error!
+file: ./test/position/apply_offset.gleam
+test_name: hit_wall_test
+---
+Error("Invalid index `8` passed! Rank indices are only expected to be 0-7.")

--- a/birdie_snapshots/expected_b1_knight_on_initial_board_to_be_able_to_move_to_a3_and_c3.accepted
+++ b/birdie_snapshots/expected_b1_knight_on_initial_board_to_be_able_to_move_to_a3_and_c3.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.6
+title: Expected b1 knight on initial board to be able to move to a3 and c3!
+file: ./test/generate/knight.gleam
+test_name: initial_test
+---
+["b1 -> a3", "b1 -> c3"]

--- a/birdie_snapshots/expected_one_up_from_e2_to_be_e3.accepted
+++ b/birdie_snapshots/expected_one_up_from_e2_to_be_e3.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.6
+title: Expected one up from e2 to be e3!
+file: ./test/position/apply_offset.gleam
+test_name: one_forward_test
+---
+e3

--- a/birdie_snapshots/expected_three_down_right_from_g5_to_be_d2.accepted
+++ b/birdie_snapshots/expected_three_down_right_from_g5_to_be_d2.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.6
+title: Expected three down right from g5 to be d2!
+file: ./test/position/apply_offset.gleam
+test_name: down_left_test
+---
+d2

--- a/birdie_snapshots/given_the_initial_board,_but_with_a_white_queen_on_d7,_expected_the_b8_knight_to_be_able_to_move_to_a6,_c6,_and_capture_on_d7.accepted
+++ b/birdie_snapshots/given_the_initial_board,_but_with_a_white_queen_on_d7,_expected_the_b8_knight_to_be_able_to_move_to_a6,_c6,_and_capture_on_d7.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.6
+title: Given the initial board, but with a white queen on d7, expected the b8 knight to be able to move to a6, c6, and capture on d7!
+file: ./test/generate/knight.gleam
+test_name: capturing_test
+---
+["b8 -> a6", "b8 -> c6", "Capture b8 -> d7"]

--- a/birdie_snapshots/queen_on_d1_with_no_pawn_in_front_of_it_can_move_to_d{2_6},_and_capture_to_d7.accepted
+++ b/birdie_snapshots/queen_on_d1_with_no_pawn_in_front_of_it_can_move_to_d{2_6},_and_capture_to_d7.accepted
@@ -4,4 +4,4 @@ title: Queen on d1 with no pawn in front of it can move to d{2-6}, and capture t
 file: ./test/generate/sliding.gleam
 test_name: queen_goes_up_test
 ---
-["Capture d1 -> d7", "d1 -> d2", "d1 -> d3", "d1 -> d4", "d1 -> d5", "d1 -> d6"]
+["d1 -> d2", "d1 -> d3", "d1 -> d4", "d1 -> d5", "d1 -> d6", "Capture d1 -> d7"]

--- a/birdie_snapshots/rook_on_d4_can_see_all_of_rank_4,_and_d{3,_7}.accepted
+++ b/birdie_snapshots/rook_on_d4_can_see_all_of_rank_4,_and_d{3,_7}.accepted
@@ -4,4 +4,4 @@ title: Rook on d4 can see all of rank 4, and d{3, 7}!
 file: ./test/generate/sliding.gleam
 test_name: rook_test
 ---
-["Capture d4 -> d7", "d4 -> d5", "d4 -> d6", "d4 -> d3", "d4 -> c4", "d4 -> b4", "d4 -> a4", "d4 -> e4", "d4 -> f4", "d4 -> g4", "d4 -> h4"]
+["d4 -> a4", "d4 -> b4", "d4 -> c4", "d4 -> d3", "d4 -> d5", "d4 -> d6", "Capture d4 -> d7", "d4 -> e4", "d4 -> f4", "d4 -> g4", "d4 -> h4"]

--- a/birdie_snapshots/white_pawn_can_en_passant_to_d6,_or_go_forward_to_e6.accepted
+++ b/birdie_snapshots/white_pawn_can_en_passant_to_d6,_or_go_forward_to_e6.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.6
+title: White pawn can en passant to d6, or go forward to e6!
+file: ./test/generate/pawn.gleam
+test_name: passant_test
+---
+["En Passant e5 -> d6", "e5 -> e6"]

--- a/birdie_snapshots/white_pawn_can_go_forward_to_e6,_or_en_passant_to_d6.accepted
+++ b/birdie_snapshots/white_pawn_can_go_forward_to_e6,_or_en_passant_to_d6.accepted
@@ -1,7 +1,0 @@
----
-version: 1.2.6
-title: White pawn can go forward to e6, or en passant to d6!
-file: ./test/generate/pawn.gleam
-test_name: passant_test
----
-["e5 -> e6", "En Passant e5 -> d6"]

--- a/birdie_snapshots/white_pawn_on_e2_can_go_to_e3_and_e4.accepted
+++ b/birdie_snapshots/white_pawn_on_e2_can_go_to_e3_and_e4.accepted
@@ -4,4 +4,4 @@ title: White pawn on e2 can go to e3 and e4!
 file: ./test/generate/pawn.gleam
 test_name: white_pawn_double_move_test
 ---
-["e2 -> e4", "e2 -> e3"]
+["e2 -> e3", "e2 -> e4"]

--- a/src/chess/board.gleam
+++ b/src/chess/board.gleam
@@ -136,7 +136,7 @@ fn obstructed_distance_loop(
   // gone too far and gone off the board edge -- return the accumulated distance
   // immediately, without a capture since we never hit one
   use new_pos <- choose.cases(
-    position.from_offset(pos, 1, dir),
+    position.in_direction(pos, 1, dir),
     on_error: fn(_) { NonCapture(distance) },
   )
 

--- a/src/chess/offset.gleam
+++ b/src/chess/offset.gleam
@@ -1,0 +1,45 @@
+import chess/sliding.{
+  type Direction, Down, DownLeft, DownRight, Left, Right, Up, UpLeft, UpRight,
+}
+
+pub type Offset {
+  Offset(vertical: Int, horizontal: Int)
+}
+
+/// Given a direction, and a distance in that direction, return an offset.
+/// Note that offsets aren't checked to be valid - since they're not associated with
+/// any position. The Position module is responsible for applying an offset to get
+/// a new position, but even that won't check if the square is actually movable.
+/// These limitations should be addressed by not working with offsets directly -
+/// they're simply a helpful tool for modules like Generate.
+pub fn in_direction(dir: Direction, dist: Int) -> Offset {
+  let single_distance = directional_offsets(dir)
+
+  Offset(single_distance.vertical * dist, single_distance.horizontal * dist)
+}
+
+pub fn knight_offsets() -> List(Offset) {
+  [
+    Offset(1, 2),
+    Offset(1, -2),
+    Offset(-1, 2),
+    Offset(-1, -2),
+    Offset(2, 1),
+    Offset(2, -1),
+    Offset(-2, 1),
+    Offset(-2, -1),
+  ]
+}
+
+fn directional_offsets(dir: Direction) -> Offset {
+  case dir {
+    Up -> Offset(1, 0)
+    Down -> Offset(-1, 0)
+    Right -> Offset(0, 1)
+    Left -> Offset(0, -1)
+    UpRight -> Offset(1, 1)
+    DownLeft -> Offset(-1, -1)
+    UpLeft -> Offset(1, -1)
+    DownRight -> Offset(-1, 1)
+  }
+}

--- a/src/chess/position.gleam
+++ b/src/chess/position.gleam
@@ -49,7 +49,7 @@ pub fn from_indices(col col: Int, row row: Int) -> Result(Position, String) {
 /// position. This will fail if the direction went off the board - it's recommended
 /// to use `move.obstructed_distance` to find the maximum distance for a given
 /// direction that one can go in an actual game (inclusive of captures)
-pub fn from_offset(
+pub fn in_direction(
   position pos: Position,
   distance dist: Int,
   direction dir: Direction,

--- a/src/chess/position.gleam
+++ b/src/chess/position.gleam
@@ -96,6 +96,14 @@ pub fn to_string(position pos: Position) -> String {
   file <> rank
 }
 
+// Returns a pair that looks like #(rank, file). 0-based indexing.
+pub fn to_indices(position pos: Position) -> #(Int, Int) {
+  let rank_index = pos.rank |> rank.to_index
+  let file_index = pos.file |> file.to_index
+
+  #(rank_index, file_index)
+}
+
 /// Get the rank of the position, typically thought of as the row
 pub fn get_rank(position pos: Position) -> Rank {
   pos.rank

--- a/src/chess/position.gleam
+++ b/src/chess/position.gleam
@@ -2,9 +2,7 @@ import chess/constants.{col_len, row_len}
 import chess/file.{type File}
 import chess/offset.{type Offset}
 import chess/rank.{type Rank}
-import chess/sliding.{
-  type Direction, Down, DownLeft, DownRight, Left, Right, Up, UpLeft, UpRight,
-}
+import chess/sliding.{type Direction}
 import gleam/order.{type Order}
 
 import gleam/bool
@@ -67,18 +65,8 @@ pub fn in_direction(
   distance dist: Int,
   direction dir: Direction,
 ) -> Result(Position, String) {
-  let row = pos.rank |> rank.to_index
-  let col = pos.file |> file.to_index
-  case dir {
-    Up -> from_indices(row: row + dist, col: col)
-    Down -> from_indices(row: row - dist, col: col)
-    Right -> from_indices(row:, col: col + dist)
-    Left -> from_indices(row:, col: col - dist)
-    UpRight -> from_indices(row: row + dist, col: col + dist)
-    UpLeft -> from_indices(row: row + dist, col: col - dist)
-    DownRight -> from_indices(row: row - dist, col: col + dist)
-    DownLeft -> from_indices(row: row - dist, col: col - dist)
-  }
+  let offset = offset.in_direction(dir, dist)
+  apply_offset(pos, offset)
 }
 
 /// Takes a classical index (0 being the top left) and turn it into a

--- a/src/chess/position.gleam
+++ b/src/chess/position.gleam
@@ -1,5 +1,6 @@
 import chess/constants.{col_len, row_len}
 import chess/file.{type File}
+import chess/offset.{type Offset}
 import chess/rank.{type Rank}
 import chess/sliding.{
   type Direction, Down, DownLeft, DownRight, Left, Right, Up, UpLeft, UpRight,
@@ -43,6 +44,18 @@ pub fn from_indices(col col: Int, row row: Int) -> Result(Position, String) {
   use file <- result.try(col |> file.from_index)
 
   Position(rank:, file:) |> Ok
+}
+
+pub fn apply_offset(pos: Position, offset: Offset) -> Result(Position, String) {
+  let file = pos.file |> file.to_index
+  // Changing the file moves you horizontally
+  let file_change = offset.horizontal
+
+  let rank = pos.rank |> rank.to_index
+  // Changing the rank moves you vertically
+  let rank_change = offset.vertical
+
+  from_indices(file + file_change, rank + rank_change)
 }
 
 /// Take an existing position, a distance, and a direction, and return a new

--- a/src/legal/generate.gleam
+++ b/src/legal/generate.gleam
@@ -16,8 +16,8 @@ import gleam/bool
 import gleam/int
 import gleam/list
 import gleam/result
-import legal/move.{type Move, Passant}
 import legal/change.{Change}
+import legal/move.{type Move, Passant}
 
 /// Given a board and a position, get all the legal moves that the piece at that
 /// position can make. An move wraps a Change, so we can differentiate things like
@@ -56,11 +56,7 @@ fn legal_pawn_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {
   |> list.append(en_passant_moves)
 }
 
-fn pawn_vertical_moves(
-  game: Game,
-  pos: Position,
-  piece: Piece,
-) -> List(Move) {
+fn pawn_vertical_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {
   let board = game.board
 
   // A 1-based index, with 0 representing the bottom row
@@ -80,7 +76,7 @@ fn pawn_vertical_moves(
   // If this failed, we're at the edge and didn't promote into a queen! Means there
   // was bad logic when it came to promotion.
   let assert Ok(new_pos) =
-    position.from_offset(distance: 1, position: pos, direction: dir)
+    position.in_direction(distance: 1, position: pos, direction: dir)
 
   let square = board.get_pos(board, new_pos)
 
@@ -102,7 +98,7 @@ fn pawn_vertical_moves(
   // The `can_double_move` check means we're in no danger of hitting the edge
   // of the board
   let assert Ok(new_pos) =
-    position.from_offset(distance: 2, position: pos, direction: dir)
+    position.in_direction(distance: 2, position: pos, direction: dir)
 
   let square = board.get_pos(board, new_pos)
 
@@ -115,11 +111,7 @@ fn pawn_vertical_moves(
   }
 }
 
-fn pawn_diagonal_moves(
-  game: Game,
-  pos: Position,
-  piece: Piece,
-) -> List(Move) {
+fn pawn_diagonal_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {
   let board = game.board
 
   let dirs = case piece.color {
@@ -132,7 +124,7 @@ fn pawn_diagonal_moves(
 
   // If this errors out since we're by an edge, simply don't add it to the list,
   // thanks to `filter_map`
-  use pos_in_dir <- result.try(position.from_offset(
+  use pos_in_dir <- result.try(position.in_direction(
     distance: 1,
     position: pos,
     direction: dir,
@@ -232,7 +224,7 @@ fn legal_sliding_moves(
         // non-captures for all the moves that were of a smaller distance (if they
         // exist)
         let assert Ok(capture_pos) =
-          position.from_offset(current_pos, max_distance, dir)
+          position.in_direction(current_pos, max_distance, dir)
         let capture = Change(current_pos, capture_pos) |> move.Capture
 
         let non_captures =
@@ -269,7 +261,7 @@ fn sliding_moves_for_dir(
   list.map(distances, fn(dist) {
     // map the direction and the distance to a new position. Returns a result, but
     // if it ever fails, we must've somehow had invalid logic. Insta-fail!
-    let assert Ok(new_pos) = position.from_offset(current_pos, dist, dir)
+    let assert Ok(new_pos) = position.in_direction(current_pos, dist, dir)
 
     Change(current_pos, new_pos) |> move.Basic
   })

--- a/src/legal/generate.gleam
+++ b/src/legal/generate.gleam
@@ -12,6 +12,7 @@ import chess/sliding.{
 }
 import chess/square
 import gleam/option.{type Option}
+import gleam/string
 
 import gleam/bool
 import gleam/int
@@ -41,6 +42,15 @@ pub fn legal_moves(game: Game, pos: Position) -> Result(List(Move), String) {
       |> Ok
     }
   }
+}
+
+// Given a list of generated moves, display them for testing - first sorted, then
+// as their string representations.
+pub fn display(moves: List(Move)) -> String {
+  moves
+  |> list.sort(move.compare)
+  |> list.map(fn(move) { move |> move.to_string })
+  |> string.inspect
 }
 
 fn legal_pawn_moves(game: Game, pos: Position, piece: Piece) -> List(Move) {

--- a/src/legal/move.gleam
+++ b/src/legal/move.gleam
@@ -1,7 +1,7 @@
 import chess/board.{type Board}
 import chess/color.{type Color}
 import chess/game.{type Game, Game}
-import gleam/order.{type Order, Gt, Lt}
+import gleam/order.{type Order}
 import legal/change.{type Change}
 
 pub type Move {
@@ -13,12 +13,7 @@ pub type Move {
 }
 
 pub fn compare(first: Move, second: Move) -> Order {
-  case first, second {
-    Basic(_), Basic(_) -> change.compare(first.change, second.change)
-    Basic(_), _ -> Lt
-    _, Basic(_) -> Gt
-    _, _ -> change.compare(first.change, second.change)
-  }
+  change.compare(first.change, second.change)
 }
 
 pub fn to_string(move: Move) -> String {

--- a/test/generate/knight.gleam
+++ b/test/generate/knight.gleam
@@ -1,0 +1,62 @@
+import birdie
+import chess/board
+import chess/color.{White}
+import chess/game
+import chess/piece
+import chess/position
+import chess/square
+import legal/generate
+
+pub fn all_options_test() {
+  // Empty board, other than a knight on d4
+  let assert Ok(my_board) = board.from_fen("8/8/8/8/3N4/8/8/8")
+  let assert Ok(pos) = position.new("d4")
+
+  // Create a Game instance using my custom board
+  let game =
+    game.initial()
+    |> game.setup_board(fn(_) { my_board })
+
+  let assert Ok(moves) = generate.legal_moves(game, pos)
+
+  moves
+  |> generate.display
+  |> birdie.snap(
+    "Expected all the valid knight moves on an empty board - b3, b5, c2, c6, e2, e6, f3, and f5!",
+  )
+}
+
+pub fn initial_test() {
+  let game = game.initial()
+  // Bottom left knight
+  let assert Ok(pos) = position.new("b1")
+
+  let assert Ok(moves) = generate.legal_moves(game, pos)
+
+  moves
+  |> generate.display
+  |> birdie.snap(
+    "Expected b1 knight on initial board to be able to move to a3 and c3!",
+  )
+}
+
+pub fn capturing_test() {
+  // Initial board, but with a white queen on d7, capturable by the b8 knight
+  let game =
+    game.initial()
+    |> game.setup_board(fn(board) {
+      let white_queen_square = piece.Queen(White) |> square.Some
+      let assert Ok(pos) = position.new("d7")
+      board |> board.set_pos(pos, white_queen_square)
+    })
+
+  let assert Ok(pos) = position.new("b8")
+
+  let assert Ok(moves) = generate.legal_moves(game, pos)
+
+  moves
+  |> generate.display
+  |> birdie.snap(
+    "Given the initial board, but with a white queen on d7, expected the b8 knight to be able to move to a6, c6, and capture on d7!",
+  )
+}

--- a/test/generate/pawn.gleam
+++ b/test/generate/pawn.gleam
@@ -3,14 +3,10 @@ import chess/color
 import chess/game
 import chess/piece
 import gleam/io
-import legal/move
 
 import chess/board
 import chess/position
 import chess/square
-
-import gleam/list
-import gleam/string
 
 import legal/generate
 
@@ -27,8 +23,7 @@ pub fn white_pawn_test() {
   let assert Ok(legal_moves) = generate.legal_moves(game, pos)
 
   legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
-  |> string.inspect
+  |> generate.display
   |> birdie.snap("White pawn on e4 can only go to e5!")
 }
 
@@ -45,8 +40,7 @@ pub fn black_pawn_test() {
   let assert Ok(legal_moves) = generate.legal_moves(game, pos)
 
   legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
-  |> string.inspect
+  |> generate.display
   |> birdie.snap("Black pawn on e4 can only go to e3!")
 }
 
@@ -63,8 +57,7 @@ pub fn white_pawn_double_move_test() {
   let assert Ok(legal_moves) = generate.legal_moves(game, pos)
 
   legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
-  |> string.inspect
+  |> generate.display
   |> birdie.snap("White pawn on e2 can go to e3 and e4!")
 }
 
@@ -81,8 +74,7 @@ pub fn black_pawn_double_move_test() {
   let assert Ok(legal_moves) = generate.legal_moves(game, pos)
 
   legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
-  |> string.inspect
+  |> generate.display
   |> birdie.snap("Black pawn on a7 can go to a6 and a5!")
 }
 
@@ -100,9 +92,8 @@ pub fn passant_test() {
   let assert Ok(legal_moves) = generate.legal_moves(game, pawn_pos)
 
   legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
-  |> string.inspect
-  |> birdie.snap("White pawn can go forward to e6, or en passant to d6!")
+  |> generate.display
+  |> birdie.snap("White pawn can en passant to d6, or go forward to e6!")
 }
 
 pub fn capture_test() {
@@ -117,7 +108,6 @@ pub fn capture_test() {
   let assert Ok(legal_moves) = generate.legal_moves(game, pawn_pos)
 
   legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
-  |> string.inspect
+  |> generate.display
   |> birdie.snap("White pawn on e6 can capture on d7 or f7!")
 }

--- a/test/generate/sliding.gleam
+++ b/test/generate/sliding.gleam
@@ -6,11 +6,8 @@ import chess/board
 import chess/position
 import chess/square
 
-import gleam/list
-import gleam/string
-
-import legal/generate
 import legal/change.{Change}
+import legal/generate
 
 pub fn queen_goes_up_test() {
   let game = game.initial()
@@ -26,8 +23,7 @@ pub fn queen_goes_up_test() {
   let assert Ok(legal_moves) = generate.legal_moves(game, queen_pos)
 
   legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
-  |> string.inspect
+  |> generate.display
   |> birdie.snap(
     "Queen on d1 with no pawn in front of it can move to d{2-6}, and capture to d7!",
   )
@@ -48,10 +44,9 @@ pub fn bishop_test() {
   let assert Ok(legal_moves) = generate.legal_moves(game, bishop_pos)
 
   legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
-  |> string.inspect
+  |> generate.display
   |> birdie.snap(
-    "Bishop on f1 with no pawn on e2 can go to e2, d3, c4, b5, and a7!",
+    "Bishop on f1 with no pawn on e2 can go on that whole diagonal: a6, b5, c4, d3, and e2!",
   )
 }
 
@@ -68,7 +63,6 @@ pub fn rook_test() {
   let assert Ok(legal_moves) = generate.legal_moves(game, new_pos)
 
   legal_moves
-  |> list.map(fn(move) { move |> move.to_string })
-  |> string.inspect
+  |> generate.display
   |> birdie.snap("Rook on d4 can see all of rank 4, and d{3, 7}!")
 }

--- a/test/position/apply_offset.gleam
+++ b/test/position/apply_offset.gleam
@@ -1,0 +1,32 @@
+import birdie
+import chess/offset
+import chess/position
+import chess/sliding
+import gleam/string
+
+pub fn one_forward_test() {
+  let one_up = offset.in_direction(sliding.Up, 1)
+  let assert Ok(pos) = position.new("e2")
+  let assert Ok(new_pos) = position.apply_offset(pos, one_up)
+  new_pos
+  |> position.to_string
+  |> birdie.snap("Expected one up from e2 to be e3!")
+}
+
+pub fn down_left_test() {
+  let down_left = offset.in_direction(sliding.DownLeft, 3)
+  let assert Ok(pos) = position.new("g5")
+  let assert Ok(new_pos) = position.apply_offset(pos, down_left)
+  new_pos
+  |> position.to_string
+  |> birdie.snap("Expected three down right from g5 to be d2!")
+}
+
+pub fn hit_wall_test() {
+  let down_left = offset.in_direction(sliding.UpRight, 8)
+  let assert Ok(pos) = position.new("a1")
+  let applied_result = position.apply_offset(pos, down_left)
+  applied_result
+  |> string.inspect
+  |> birdie.snap("Expected applying an invalid offset to give an error!")
+}


### PR DESCRIPTION
As is now commonplace, this comes with other changes. Quick recap:
- We add a new `offset` type and module. This is now the underlying function for the `from_offset` function - but don't be too hasty, that function's been renamed to `in_direction`. 
- We add a `display` function to the generate module, for automating the sorting and to_string I've been running on all the tests. 
- While setting up all the tests to use `display`, I found that the existing sorting logic for non-basic moves was a bit unintuitive - so now a Capture or an En Passant get sorted the same as any other move.
- New tests for the knight logic and the generate logic!