### PR TITLE
generate/legal_moves: apply moves less often

### DIFF
--- a/src/profile/legal_moves.gleam
+++ b/src/profile/legal_moves.gleam
@@ -14,6 +14,12 @@ pub fn main() {
         fn() { generate.legal_moves(game) }
       }),
     ],
-    [benchmark.Data(label: "inital game", data: { game.initial() })],
+    [
+      benchmark.Data(label: "inital game", data: { game.initial() }),
+      benchmark.Data(label: "game currently in check", data: {
+        let assert Ok(game) = game.new("3r4/8/8/8/3K4/7R/8/2k5 w - - 0 1")
+        game
+      }),
+    ],
   )
 }


### PR DESCRIPTION
Fixes #20.

Applying every move to see which ones actually put us in check is
expensive - and should be avoided whenever possible. Previously, if we
weren't in check, we would apply every single move to ensure a move
didn't put us into check, or always took us out of check -- even ones
obviously didn't need to be checked.

Now, if we're not in check, we can say that most moves, that don't
change anything with the king or the positions that might be defending
it, and immediately know those are legal moves. The only ones we need to
apply and guarantee are the ones that either move the king, or move a
piece that could be defending the king.

If we are in check, most moves will be illegal. The only moves that
might be legal, and need application, are the moves that end up at a
position directly attacking the king - since that could be either a
direct move by the king, or a move attacking the enemy checking the
king.

In my testing, this makes legal move generation on the initial board
go 3.4x faster, and take 3.4x less memory. On a random board currently
in check, it became 1.7x faster, and take 1.7x less memory. Big
improvements!